### PR TITLE
build: :arrow_up: upgrade to esm only module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@nuxtus/cli",
   "version": "1.1.1",
   "description": "Command line interface for Nuxtus projects.",
-  "main": "build/src/cli.js",
+  "exports": "./build/src/cli.js",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/nuxtus/cli"
@@ -35,6 +36,9 @@
       "node14-macos-x64",
       "node14-win-x86"
     ]
+  },
+  "engines": {
+    "node": ">=14.16"
   },
   "author": "Craig Harman",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,11 +5,12 @@ import "dotenv/config"
 import { Command } from "commander"
 import chalk from "chalk"
 import clear from "clear"
-import create from "./commands/create"
+import create from "./commands/create.js"
 import figlet from "figlet"
-import types from "./commands/types"
-import { version } from "../package.json"
+import types from "./commands/types.js"
+import pkg from "../package.json" assert {type: "json"}
 
+const version = pkg.version
 const program = new Command()
 
 clear()
@@ -19,7 +20,7 @@ console.log(
 program
 	.name("nuxtus")
 	.version("v" + version)
-	.description("Nuxtus boilerplate CLI")
+	.description("Nuxtus CLI")
 
 program
 	.command("create")

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,17 +1,18 @@
+import * as CLI from "clui"
+
 import { Item, ManyItems, PartialItem } from "@directus/sdk"
 
 import { Chalk } from "chalk"
 import { Command } from "../interfaces/command.interface"
 import Generator from "@nuxtus/generator"
+import {existsSync} from "node:fs"
 import inquirer from "inquirer"
+import {
+	readdir
+} from "node:fs/promises"
 
-const CLI = require("clui")
 const Spinner = CLI.Spinner
 
-const {
-	promises: { readdir },
-	existsSync,
-} = require("fs")
 
 type CollectionItem = {
 	collection: string

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,8 +1,9 @@
+import * as CLI from "clui"
+
 import Chalk from "chalk"
 import { Command } from "../interfaces/command.interface"
 import Generator from "@nuxtus/generator"
 
-const CLI = require("clui")
 const Spinner = CLI.Spinner
 
 const create: Command = async function (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ESNext",                                /* Specify what module code is generated. */
     // "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Now an ESM module and does not use require.

BREAKING CHANGES: Now requires Node 14.16 or greater.