### PR TITLE
fix: Node 24 compat, SDK v21 support, non-interactive mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@nuxtus/cli",
-  "version": "2.1.4",
+  "name": "@resultcrafter/nuxtus-cli",
+  "version": "2.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nuxtus/cli",
-      "version": "2.1.4",
+      "name": "@resultcrafter/nuxtus-cli",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@directus/sdk": "^21.0.0",
@@ -24,7 +24,7 @@
         "nuxtus": "build/src/cli.js"
       },
       "devDependencies": {
-        "@nuxtus/generator": "1.9.4",
+        "@resultcrafter/nuxtus-generator": "file:../nuxtus-generator",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "9.2.6",
@@ -43,6 +43,44 @@
       "engines": {
         "node": "^22.0.0 || ^24.0.0",
         "npm": ">=8.5.0"
+      }
+    },
+    "../nuxtus-generator": {
+      "name": "@resultcrafter/nuxtus-generator",
+      "version": "1.9.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@directus/sdk": "^21.0.0",
+        "camelcase": "^9.0.0",
+        "chalk": "^5.0.1",
+        "nanoid": "^5.0.5",
+        "nunjucks": "^3.2.3",
+        "openapi-typescript": "^7.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.2",
+        "@rollup/plugin-babel": "7.0.0",
+        "@rollup/plugin-commonjs": "29.0.2",
+        "@rollup/plugin-node-resolve": "16.0.3",
+        "@rollup/plugin-typescript": "12.3.0",
+        "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/git": "10.0.1",
+        "@semantic-release/github": "9.2.6",
+        "@semantic-release/release-notes-generator": "12.1.0",
+        "@types/nunjucks": "3.2.6",
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "eslint": "10.0.3",
+        "rollup": "4.59.0",
+        "rollup-plugin-copy-assets": "2.0.3",
+        "semantic-release": "23.1.1",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "vitest": "4.1.0"
+      },
+      "engines": {
+        "node": "22 || 24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -572,43 +610,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nuxtus/generator": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@nuxtus/generator/-/generator-1.9.4.tgz",
-      "integrity": "sha512-vQiDB9XJHinQ47P7k6SYvnSrcrdm2fMAJhK76uLwcRCaPjH9xbZFe8OGuzYUYFNIeIqrdBUTCPCddlVyXc7MNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@directus/sdk": "^21.0.0",
-        "camelcase": "^9.0.0",
-        "chalk": "^5.0.1",
-        "nanoid": "^5.0.5",
-        "nunjucks": "^3.2.3",
-        "openapi-typescript": "^7.0.0"
-      },
-      "engines": {
-        "node": "22 || 24"
-      }
-    },
-    "node_modules/@nuxtus/generator/node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -889,81 +890,9 @@
         "node": ">=12"
       }
     },
-    "node_modules/@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@redocly/config": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@redocly/openapi-core": {
-      "version": "1.34.10",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
-      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.22.0",
-        "colorette": "1.4.0",
-        "https-proxy-agent": "7.0.6",
-        "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
-        "minimatch": "5.1.9",
-        "pluralize": "8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=18.17.0",
-        "npm": ">=9.5.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/@resultcrafter/nuxtus-generator": {
+      "resolved": "../nuxtus-generator",
+      "link": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
@@ -2128,15 +2057,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
@@ -2289,19 +2209,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-9.0.0.tgz",
-      "integrity": "sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2323,13 +2230,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -2520,13 +2420,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3174,13 +3067,6 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3865,16 +3751,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3902,13 +3778,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -7253,84 +7122,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/openapi-core": "^1.34.6",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.2.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.x"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/index-to-position": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/parse-json": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -7600,16 +7391,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -7860,16 +7641,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9106,13 +8877,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/uri-js-replace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -9446,13 +9210,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -9796,28 +9553,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@nuxtus/generator": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@nuxtus/generator/-/generator-1.9.4.tgz",
-      "integrity": "sha512-vQiDB9XJHinQ47P7k6SYvnSrcrdm2fMAJhK76uLwcRCaPjH9xbZFe8OGuzYUYFNIeIqrdBUTCPCddlVyXc7MNA==",
-      "dev": true,
-      "requires": {
-        "@directus/sdk": "^21.0.0",
-        "camelcase": "^9.0.0",
-        "chalk": "^5.0.1",
-        "nanoid": "^5.0.5",
-        "nunjucks": "^3.2.3",
-        "openapi-typescript": "^7.0.0"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "5.1.7",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-          "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-          "dev": true
-        }
-      }
-    },
     "@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -10037,65 +9772,34 @@
         "config-chain": "^1.1.11"
       }
     },
-    "@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
-      "dev": true,
+    "@resultcrafter/nuxtus-generator": {
+      "version": "file:../nuxtus-generator",
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
-      }
-    },
-    "@redocly/config": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
-      "dev": true
-    },
-    "@redocly/openapi-core": {
-      "version": "1.34.10",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
-      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
-      "dev": true,
-      "requires": {
-        "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.22.0",
-        "colorette": "1.4.0",
-        "https-proxy-agent": "7.0.6",
-        "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
-        "minimatch": "5.1.9",
-        "pluralize": "8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.9",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-          "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.2",
+        "@directus/sdk": "^21.0.0",
+        "@rollup/plugin-babel": "7.0.0",
+        "@rollup/plugin-commonjs": "29.0.2",
+        "@rollup/plugin-node-resolve": "16.0.3",
+        "@rollup/plugin-typescript": "12.3.0",
+        "@semantic-release/changelog": "6.0.3",
+        "@semantic-release/git": "10.0.1",
+        "@semantic-release/github": "9.2.6",
+        "@semantic-release/release-notes-generator": "12.1.0",
+        "@types/nunjucks": "3.2.6",
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "camelcase": "^9.0.0",
+        "chalk": "^5.0.1",
+        "eslint": "10.0.3",
+        "nanoid": "^5.0.5",
+        "nunjucks": "^3.2.3",
+        "openapi-typescript": "^7.0.0",
+        "rollup": "4.59.0",
+        "rollup-plugin-copy-assets": "2.0.3",
+        "semantic-release": "23.1.1",
+        "tslib": "2.8.1",
+        "typescript": "5.9.3",
+        "vitest": "4.1.0"
       }
     },
     "@rolldown/binding-android-arm64": {
@@ -10840,12 +10544,6 @@
         "indent-string": "^4.0.0"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
@@ -10947,12 +10645,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "camelcase": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-9.0.0.tgz",
-      "integrity": "sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==",
-      "dev": true
-    },
     "chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -10963,12 +10655,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
-    },
-    "change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true
     },
     "char-regex": {
       "version": "1.0.2",
@@ -11105,12 +10791,6 @@
     },
     "color-name": {
       "version": "1.1.4",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
     },
     "commander": {
@@ -11556,12 +11236,6 @@
       "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
       "dev": true
     },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
     "fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -12005,12 +11679,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12032,12 +11700,6 @@
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
     "json-stringify-safe": {
@@ -14180,51 +13842,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "openapi-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
-      "dev": true,
-      "requires": {
-        "@redocly/openapi-core": "^1.34.6",
-        "ansi-colors": "^4.1.3",
-        "change-case": "^5.4.4",
-        "parse-json": "^8.3.0",
-        "supports-color": "^10.2.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "index-to-position": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-          "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-          "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.26.2",
-            "index-to-position": "^1.1.0",
-            "type-fest": "^4.39.1"
-          }
-        },
-        "supports-color": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-          "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "4.41.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-          "dev": true
-        }
-      }
-    },
     "p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -14391,12 +14008,6 @@
         }
       }
     },
-    "pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "dev": true
-    },
     "postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -14551,12 +14162,6 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "dev": true
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve-from": {
@@ -15347,12 +14952,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "uri-js-replace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-      "dev": true
-    },
     "url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -15508,12 +15107,6 @@
     },
     "yallist": {
       "version": "4.0.0",
-      "dev": true
-    },
-    "yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@nuxtus/cli",
-  "version": "2.1.4",
+  "name": "@resultcrafter/nuxtus-cli",
+  "version": "2.1.5",
   "description": "Command line interface for Nuxtus projects.",
   "exports": "./build/src/cli.js",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nuxtus/cli"
+    "url": "https://github.com/resultcrafter/nuxtus-cli"
   },
   "publishConfig": {
     "access": "public",
@@ -32,7 +32,7 @@
   "author": "Craig Harman",
   "license": "MIT",
   "devDependencies": {
-    "@nuxtus/generator": "1.9.4",
+    "@resultcrafter/nuxtus-generator": "^1.9.5",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "9.2.6",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import create from "./commands/create.js"
 import token from "./commands/token.js"
 import figlet from "figlet"
 import types from "./commands/types.js"
-import pkg from "../package.json" assert { type: "json" }
+import pkg from "../package.json" with { type: "json" }
 
 const version = pkg.version
 const program = new Command()
@@ -31,6 +31,8 @@ if (major < 16) {
 	process.exit(1)
 }
 
+const collect = (value: string, previous: string[]) => previous.concat([value])
+
 clear()
 console.info(
 	chalk.green(figlet.textSync("nuxtus-cli", { horizontalLayout: "full" }))
@@ -43,18 +45,35 @@ program
 program
 	.command("create")
 	.description("Create pages based on Directus collection(s).")
-	.action(() => create(chalk))
+	.option('-c, --collection <name>', 'Collection name (repeatable)', collect, [] as string[])
+	.action((opts: any) => {
+		const isNonInteractive = opts.collection && opts.collection.length > 0
+		if (!isNonInteractive) {
+			clear()
+			console.info(chalk.green(figlet.textSync("nuxtus-cli", { horizontalLayout: "full" })))
+		}
+		return create(chalk, undefined, opts.collection)
+			.then(() => process.exit(0))
+			.catch(() => process.exit(1))
+	})
 
 program
 	.command("types")
 	.description("Create type definitions from Directus collection(s).")
-	.action(() => types(chalk))
+	.option('-q, --quiet', 'Suppress banner for scripted use')
+	.action((opts: any) => {
+		if (!opts.quiet) {
+			clear()
+			console.info(chalk.green(figlet.textSync("nuxtus-cli", { horizontalLayout: "full" })))
+		}
+		return types(chalk).then(() => process.exit(0)).catch(() => process.exit(1))
+	})
 
 program
 	.command("token")
 	.description(
 		"Create static token and use for authentication instead of email/password."
 	)
-	.action(() => token(chalk))
+	.action(() => token(chalk).then(() => process.exit(0)).catch(() => process.exit(1)))
 
 program.parse()

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,7 +1,7 @@
 import * as CLI from "clui"
 
 import { Command } from "../interfaces/command.interface"
-import Generator from "@nuxtus/generator"
+import Generator from "@resultcrafter/nuxtus-generator"
 import chalk from "chalk"
 import { existsSync } from "node:fs"
 import inquirer from "inquirer"

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -7,7 +7,7 @@ import { existsSync } from "node:fs"
 import inquirer from "inquirer"
 import { readdir } from "node:fs/promises"
 
-const Spinner = CLI.Spinner
+const Spinner = CLI.default.Spinner
 
 type CollectionItem = {
 	collection: string
@@ -23,11 +23,45 @@ const getDirectories = async (source: string) =>
 		.filter((dirent: any) => dirent.isDirectory())
 		.map((dirent: any) => dirent.name)
 
+async function createPages(
+	collectionNames: string[],
+	filteredCollections: any[],
+	nuxtus: Generator,
+	localChalk: typeof chalk
+): Promise<void> {
+	const notFound = collectionNames.filter(
+		(name: string) => !filteredCollections.find((o: any) => o.collection === name)
+	)
+	if (notFound.length > 0) {
+		console.error(localChalk.red(`Collection(s) not found: ${notFound.join(", ")}`))
+		process.exit(1)
+	}
+
+	let spinner = new Spinner(`Creating pages from collections...`)
+	spinner.start()
+	await Promise.all(
+		collectionNames.map(async (collectionName: string) => {
+			const collection = filteredCollections.find(
+				(o: any) => o.collection === collectionName
+			)
+			const singleton: boolean = collection!.meta?.singleton || false
+			return nuxtus.createPage(collectionName, singleton)
+		})
+	).catch((err: any) => {
+		spinner.stop()
+		console.error(localChalk.red("Error creating page(s): " + err.message))
+		process.exit(1)
+	})
+	spinner.stop()
+	console.info(localChalk.green("✅ All collections created. Restart Nuxt to see them."))
+}
+
 let create: Command
 
 export default create = async function (
 	localChalk: typeof chalk,
-	nuxtus?: Generator
+	nuxtus?: Generator,
+	requestedCollections?: string[]
 ): Promise<void> {
 	try {
 		if (nuxtus === undefined) nuxtus = new Generator(localChalk)
@@ -36,13 +70,12 @@ export default create = async function (
 		return
 	}
 
-	const collectionData = await nuxtus.getCollections()
+	const collectionData: any = await nuxtus.getCollections()
+	const allCollections = Array.isArray(collectionData)
+		? collectionData
+		: (collectionData.data || [])
 
-	if (
-		collectionData.data === null ||
-		collectionData.data === undefined ||
-		collectionData.data.length === 0
-	) {
+	if (allCollections.length === 0) {
 		console.warn(localChalk.yellow("No Directus collections found."))
 		console.warn()
 		return
@@ -53,7 +86,7 @@ export default create = async function (
 	if (existsSync("pages")) {
 		existingCollections = await getDirectories("pages")
 	}
-	const filteredCollections = collectionData.data.filter((collection: any) => {
+	const filteredCollections = allCollections.filter((collection: any) => {
 		return (
 			!collection.collection.startsWith("directus_") &&
 			!existingCollections.includes(collection.collection) &&
@@ -63,6 +96,11 @@ export default create = async function (
 	const collections = filteredCollections.map((collection: any) => {
 		return collection.collection
 	})
+
+	if (requestedCollections && requestedCollections.length > 0) {
+		await createPages(requestedCollections, filteredCollections, nuxtus, localChalk)
+		return
+	}
 
 	if (collections.length === 0) {
 		console.warn(localChalk.yellow("No collections need to be created."))

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -20,8 +20,9 @@ const token: Command = async function (
 	let token
 	try {
 		token = await nuxtus.generateStaticToken()
-	} catch (err) {
-		throw new Error(`Unable to save token to Directus. ${err}`)
+	} catch (err: any) {
+		console.error(chalk.red(`Unable to register token with Directus. .env not modified. ${err.message || err}`))
+		return
 	}
 
 	// add the token to nuxt.config.ts

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs"
 
 import Chalk from "chalk"
 import { Command } from "../interfaces/command.interface"
-import Generator from "@nuxtus/generator"
+import Generator from "@resultcrafter/nuxtus-generator"
 import path from "path"
 
 const token: Command = async function (

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -4,7 +4,7 @@ import Chalk from "chalk"
 import { Command } from "../interfaces/command.interface"
 import Generator from "@nuxtus/generator"
 
-const Spinner = CLI.Spinner
+const Spinner = CLI.default.Spinner
 
 const create: Command = async function (
 	chalk: typeof Chalk,
@@ -16,7 +16,7 @@ const create: Command = async function (
 		// Error will already be displayed by Generator, so just exit
 		return
 	}
-	nuxtus.createTypes(chalk)
+	await nuxtus.createTypes(chalk)
 }
 
 export default create

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -2,7 +2,7 @@ import * as CLI from "clui"
 
 import Chalk from "chalk"
 import { Command } from "../interfaces/command.interface"
-import Generator from "@nuxtus/generator"
+import Generator from "@resultcrafter/nuxtus-generator"
 
 const Spinner = CLI.default.Spinner
 

--- a/src/interfaces/command.interface.ts
+++ b/src/interfaces/command.interface.ts
@@ -1,5 +1,5 @@
 import Chalk from "chalk"
-import Generator from "@nuxtus/generator"
+import Generator from "@resultcrafter/nuxtus-generator"
 
 export interface Command {
 	(chalk: typeof Chalk, nuxtus?: Generator): Promise<void>


### PR DESCRIPTION
- Change assert { type: 'json' } to with { type: 'json' } (Node 24)
- Fix CLI.default.Spinner for clui CJS/ESM interop (Node 24)
- Add process.exit() handlers to all command actions (SDK keeps connections alive)
- Add await to createTypes() call in types command
- Normalize getCollections() response for SDK v21 (flat array vs {data:[]})
- Add --collection/-c option for non-interactive page creation
- Add --quiet/-q option for banner-suppressed types generation
- Add createPages() helper with not-found error handling
- Fix token command: don't modify .env if generateStaticToken() fails